### PR TITLE
Minor fixes and improvements

### DIFF
--- a/FlurryBannerCustomEvent.m
+++ b/FlurryBannerCustomEvent.m
@@ -42,8 +42,6 @@
 - (void)requestAdWithSize:(CGSize)size customEventInfo:(NSDictionary *)info
 {
     MPLogInfo(@"MoPub instructs Flurry to display an ad, %@, of size: %f, %f" , self, size.width, size.height);
-    [FlurryMPConfig sharedInstance];
-    
     self.adSpaceName = [info objectForKey:@"adSpaceName"];
     if (!self.adSpaceName) {
         self.adSpaceName = FlurryBannerAdSpaceName;

--- a/FlurryInterstitialCustomEvent.m
+++ b/FlurryInterstitialCustomEvent.m
@@ -44,9 +44,7 @@
 
 - (void)requestInterstitialWithCustomEventInfo:(NSDictionary *)info
 {
-    MPLogInfo(@"MoPub instructs Flurry to display an interstitial ad");
-    [FlurryMPConfig sharedInstance];
-    
+    MPLogInfo(@"MoPub instructs Flurry to display an interstitial ad");    
     self.adSpaceName = [info objectForKey:@"adSpaceName"];
     if (!self.adSpaceName) {
         self.adSpaceName = FlurryInterstitialAdSpaceTakeoverName;

--- a/FlurryInterstitialCustomEvent.m
+++ b/FlurryInterstitialCustomEvent.m
@@ -80,6 +80,7 @@
 
 - (void) adInterstitialDidRender:(FlurryAdInterstitial*)interstitialAd {
     MPLogDebug(@"Flurry interstital ad was rendered.");
+    [self.delegate interstitialCustomEventDidAppear:self];
     [self.delegate trackImpression];
 }
 

--- a/FlurryMPConfig.h
+++ b/FlurryMPConfig.h
@@ -9,7 +9,6 @@
 #import <Foundation/Foundation.h>
 #import "Flurry.h"
 
-#define FlurryAPIKey @"YOUR_API_KEY"  // replace this with your own Flurry API key
 #define FlurryMediationOrigin @"Flurry_Mopub_iOS"
 #define FlurryAdapterVersion @"7.2.1"
 
@@ -31,6 +30,6 @@
 
 @interface FlurryMPConfig : NSObject
 
-+ (id)sharedInstance;
++ (void)initializeWithFlurryAPIKey:(NSString *)flurryAPIKey;
 
 @end

--- a/FlurryMPConfig.m
+++ b/FlurryMPConfig.m
@@ -10,22 +10,14 @@
 
 @implementation FlurryMPConfig
 
-+ (id)sharedInstance {
-    static FlurryMPConfig *si = nil;
++ (void)initializeWithFlurryAPIKey:(NSString *)flurryAPIKey
+{
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        si = [[self alloc] init];
-    });
-    return si;
-}
-
-- (id)init {
-    if (self = [super init]) {
-        [Flurry startSession:FlurryAPIKey];
+        [Flurry startSession:flurryAPIKey];
         [Flurry addOrigin:FlurryMediationOrigin withVersion:FlurryAdapterVersion];
         [Flurry setDebugLogEnabled:NO];
-    }
-    return self;
+    });
 }
 
 @end

--- a/FlurryNativeAdAdapter.m
+++ b/FlurryNativeAdAdapter.m
@@ -29,37 +29,38 @@
         _adNative = adNative;
         _adNative.adDelegate = self;
         
-        NSMutableDictionary *props = [NSMutableDictionary dictionary];
-        for (int ix = 0; ix < adNative.assetList.count; ++ix) {
-            FlurryAdNativeAsset* asset = [adNative.assetList objectAtIndex:ix];
-            if ([asset.name isEqualToString:@"headline"]) {
-                [props setObject:asset.value forKey:kAdTitleKey];
-            }
-            
-            if ([asset.name isEqualToString:@"secImage"]) {
-                [props setObject:asset.value forKey:kAdIconImageKey];
-            }
-            
-            if ([asset.name isEqualToString:@"secHqImage"]) {
-                [props setObject:asset.value forKey:kAdMainImageKey];
-            }
-            
-            if ([asset.name isEqualToString:@"summary"]) {
-                [props setObject:asset.value forKey:kAdTextKey];
-            }
-           
-            if ([asset.name isEqualToString:@"appRating"]) {
-                [props setObject:asset.value forKey:kAdStarRatingKey];
-            }
-
-            if ([asset.name isEqualToString:@"callToAction"]) {
-                [props setObject:asset.value forKey:kAdCTATextKey];
-            }
-            
-        }
-        _properties = props;
+        _properties = [self convertAssetsToProperties:adNative];
     }
     return self;
+}
+
+- (NSDictionary *)convertAssetsToProperties:(FlurryAdNative *)adNative
+{
+    NSDictionary *flurryToMoPubPropertiesMap = @{
+                                                 @"headline": kAdTitleKey,
+                                                 @"secImage": kAdIconImageKey,
+                                                 @"secHqImage": kAdMainImageKey,
+                                                 @"summary": kAdTextKey,
+                                                 @"appRating": kAdStarRatingKey,
+                                                 @"callToAction": kAdCTATextKey
+                                                 };
+    
+    NSMutableDictionary *props = [NSMutableDictionary dictionary];
+    for (int ix = 0; ix < adNative.assetList.count; ++ix) {
+        FlurryAdNativeAsset* asset = [adNative.assetList objectAtIndex:ix];
+        NSString *key = flurryToMoPubPropertiesMap[asset.name];
+        if (key == nil) {
+            // If we don't have a mapping to one of the standard MoPub keys
+            // we still pass the data along using a non-standard key.
+            key = [NSString stringWithFormat:@"flurry_%@", asset.name];
+        }
+        
+        if (key && asset.value) {
+            [props setObject:asset.value forKey:key];
+        }
+    }
+    
+    return [props copy];
 }
 
 - (void)dealloc {

--- a/FlurryNativeAdAdapter.m
+++ b/FlurryNativeAdAdapter.m
@@ -55,12 +55,35 @@
             key = [NSString stringWithFormat:@"flurry_%@", asset.name];
         }
         
-        if (key && asset.value) {
-            [props setObject:asset.value forKey:key];
+        id value = [self normalizeValueForKey:key value:asset.value];
+        
+        if (key && value) {
+            [props setObject:value forKey:key];
         }
     }
     
     return [props copy];
+}
+
+- (id)normalizeValueForKey:(NSString *)key value:(id)value {
+    id normalizedValue = value;
+    if ([key isEqualToString:kAdStarRatingKey]) {
+        if ([value isKindOfClass:[NSNumber class]]) {
+            CGFloat starRating = [value doubleValue];
+            if (starRating < kStarRatingMinValue || starRating > kStarRatingMaxValue) {
+                normalizedValue = nil; // star rating is out of bounds
+            }
+        } else if ([value isKindOfClass:[NSString class]]) {
+            // We assume the value is in the range [0, 100]
+            CGFloat starRating = [value doubleValue];
+            CGFloat normalizedStarRating = starRating / 100 * kUniversalStarRatingScale;
+            normalizedValue = [NSNumber numberWithDouble:normalizedStarRating];
+        } else {
+            normalizedValue = nil; // MoPub won't know what to do with this star rating
+        }
+    }
+    
+    return normalizedValue;
 }
 
 - (void)dealloc {

--- a/FlurryNativeCustomEvent.m
+++ b/FlurryNativeCustomEvent.m
@@ -41,16 +41,6 @@
     FlurryNativeAdAdapter *adAdapter = [[FlurryNativeAdAdapter alloc] initWithFlurryAdNative:flurryAd];
     MPNativeAd *interfaceAd = [[MPNativeAd alloc] initWithAdAdapter:adAdapter];
     
-    NSMutableArray *imageURLs = [NSMutableArray array];
-    for (int ix = 0; ix < flurryAd.assetList.count; ++ix) {
-        FlurryAdNativeAsset* asset = [flurryAd.assetList objectAtIndex:ix];
-        if ([asset.name isEqualToString:@"secImage"]) {
-            [imageURLs addObject:[NSURL URLWithString:asset.value]];
-        }
-        if ([asset.name isEqualToString:@"secHqImage"]) {
-            [imageURLs addObject:[NSURL URLWithString:asset.value]];
-        }
-    }
     [self.delegate nativeCustomEvent:self didLoadAd:interfaceAd];
 }
 

--- a/FlurryNativeCustomEvent.m
+++ b/FlurryNativeCustomEvent.m
@@ -12,7 +12,6 @@
 #import "MPNativeAd.h"
 #import "MPNativeAdError.h"
 #import "MPLogging.h"
-#import "FlurryMPConfig.h"
 
 @interface FlurryNativeCustomEvent () <FlurryAdNativeDelegate>
 
@@ -24,7 +23,6 @@
 
 - (void)requestAdWithCustomEventInfo:(NSDictionary *)info
 {
-    [FlurryMPConfig sharedInstance];
     NSString *adSpace = [info objectForKey:@"adSpaceName"];
     if (adSpace) {
         self.adNative = [[FlurryAdNative alloc] initWithSpace:adSpace];

--- a/README.md
+++ b/README.md
@@ -4,106 +4,95 @@ Flurry iOS Adapter for MoPub
 Adapter version 7.2.1 - Updated 10/22/2015
 ------------------------------------------
 
-This version of the adapter works with MoPub iOS SDK 4+. If using older versions of the MoPub SDK, please refer to
-[version 7.2.0](https://github.com/flurry/FlurryAdapterForMoPubiOS/tree/v7.2.1_for_mopub_pre_4.0.0) of the adapter.
+This version of the adapter works with MoPub iOS SDK 4+. If using older versions of the MoPub SDK, please refer to [version 7.2.0](https://github.com/flurry/FlurryAdapterForMoPubiOS/tree/v7.2.1_for_mopub_pre_4.0.0) of the adapter.
 
 
 ###  Mediate Flurry Ads through MoPub
 
-To integrate Flurry as the Custom Native Network in the MoPub ad serving flow, you need the
-Custom Event Class code incorporated into your application, in addition to the Flurry SDK.
+To integrate Flurry as the Custom Native Network in the MoPub ad serving flow, you need the Custom Event Class code incorporated into your application, in addition to the Flurry SDK.
+
 Three quick steps are necessary:
 
-1. Integrate the Flurry SDK and Flurry adapter for MoPub code into your app
-2. Configure Flurry's Ad space(s)
-3. Configure MoPub to mediate Flurry
+1. Integrate the Flurry SDK and Flurry adapter for MoPub code into your app.
+2. Configure Flurry's Ad space(s).
+3. Configure MoPub to mediate Flurry.
 
 #### Integrate the Flurry SDK and Flurry adapter for MoPub code into your app
 
-1. If your application is not yet using Flurry analytics, create a new application on Flurry's
-dev portal. After logging into https://dev.flurry.com , select the Applications tab and from the
-top righthand corner select Add New Application. In case your application is already tracked
-by Flurry, you can download the latest SDK from the adjacent top righthand
-link.
+1. If your application is not yet using Flurry analytics, create a new application on Flurry's dev portal. After logging into https://dev.flurry.com , select the Applications tab and from the top righthand corner select Add New Application. In case your application is already tracked by Flurry, you can download the latest SDK from the adjacent top righthand link.
 
     ![Screenshot showing download links on Flurry dev portal](imgs/add_project_link.png)
 
-2. [Add the Flurry SDK](https://developer.yahoo.com/flurry/docs/publisher/code/ios/#integrate-the-sdk-with-your-app) to 
-your Xcode project.
+2. [Add the Flurry SDK](https://developer.yahoo.com/flurry/docs/publisher/code/ios/#integrate-the-sdk-with-your-app) to your Xcode project.
 
 3. From the Flurry dashboard, record the API key for your iOS project. This will identify your app in the Flurry system.
 
-4. Add the Flurry adapter classes for MoPub to your project.
+4. Install the adapter either by adding the following to your Podfile
 
-5. Follow the [MoPub Custom Event integration steps](https://github.com/mopub/mopub-ios-sdk/wiki/Integrating-Third-Party-Ad-Networks)
-for integrating banner and interstitial ads.
+      pod 'FlurryAdapterForMoPubiOS'
 
-   The necessary files for banner and interstitial mediation should have already been added in step 3. These files are:
-    * FlurryBannerCustomEvent.(h|m)
-    * FlurryInterstitialCustomEvent.(h|m)
+    or by manually adding the Flurry adapter classes for MoPub to your project.
+
+5. Follow the [MoPub Custom Event integration steps](https://github.com/mopub/mopub-ios-sdk/wiki/Integrating-Third-Party-Ad-Networks) for integrating banner and interstitial ads.
+
+The necessary files for banner and interstitial mediation should have already been added in step 3. These files are:
+
++ FlurryBannerCustomEvent.(h|m)
++ FlurryInterstitialCustomEvent.(h|m)
 
 6. The steps to integrate Flurry Native Ads via MoPub are similar to those described [here](https://github.com/mopub/mopub-ios-sdk/wiki/Integrating-Native-Third-Party-Ad-Networks):
 
-   For Flurry, the necessary for native mediation files are:
-    * FlurryNativeCustomEvent.(h|m)
-    * FlurryNativeAdAdapter.(h|m)
+For Flurry, the necessary for native mediation files are:
 
-7. Make sure to add your Flurry API key in `FlurryMPConfig.h`
++ FlurryNativeCustomEvent.(h|m)
++ FlurryNativeAdAdapter.(h|m)
+
+7. Make sure to add your initialize the adapter with your Flurry API key as early as possible, preferably in you UIApplicationDelegate
 
 ```
-#define FlurryAPIKey @"YOUR_API_KEY"  // replace this with your own Flurry API key
-``` 
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+    [FlurryMPConfig initializeWithFlurryAPIKey:@"YOUR_FLURRY_API_KEY"];
+    return YES;
+}
+```
 
 #### Configure Flurry Ad space(s)
 
-For each MoPub ad unit that you would like to mediate Flurry through, please create a matching ad
-space on Flurry's dev portal ( http://dev.flurry.com ). Log into the developer portal and navigate
-to the **Publishers** tab. On the lefthand navigation bar select **Inventory** and then
-**Ad Spaces**.
+For each MoPub ad unit that you would like to mediate Flurry through, please create a matching ad space on Flurry's dev portal ( http://dev.flurry.com ). Log into the developer portal and navigate to the **Publishers** tab. On the lefthand navigation bar select **Inventory** and then **Ad Spaces**.
 
 ![Screenshot showing ad space navigation on Flurry dev portal](imgs/ad_space_navigation.png)
 
-With **Ad Spaces** selected you’ll see an index of previously created ad spaces. To set up a new one,
-Click on the **New Ad Space** button on the top right. The Ad Space setup screen has four modules.
+With **Ad Spaces** selected you’ll see an index of previously created ad spaces. To set up a new one, click on the **New Ad Space** button on the top right. The Ad Space setup screen has four modules.
 
-The Basic Setup section includes fields required to define the name, application, dimensions,
-placement and orientation of the ad space.
+The Basic Setup section includes fields required to define the name, application, dimensions, placement and orientation of the ad space.
 
 ![Screenshot showing ad space navigation on Flurry dev portal](imgs/native_ad_setup.png)
 
 The basic setup is all you need for most integrations and you can click the "Save Ad Space" button.
 
-Please note that mediating Flurry through MoPub requires no additional Flurry-related code.
-The Flurry Advertising code is already incorporated in this adapter's code.
+Please note that mediating Flurry through MoPub requires no additional Flurry-related code. The Flurry Advertising code is already incorporated in this adapter's code.
 
 #### Configure MoPub to mediate Flurry
 
 Flurry's custom events are implemented in accordance with [instructions provided by MoPub](https://github.com/mopub/mopub-ios-sdk/wiki/Custom-Events).
 
-After you incorporate the Flurry files into your project, you need to configure Flurry as the Custom 
-Native Network into your mediation flow. Please follow instructions provided by MoPub 
-(for [banner, interstitial](https://dev.twitter.com/mopub/ui-setup/custom-network-setup) or [native](https://dev.twitter.com/mopub/ui-setup/network-setup-custom-native)) 
-with any of the Flurry custom events class noted below:
+After you incorporate the Flurry files into your project, you need to configure Flurry as the Custom Native Network into your mediation flow. Please follow instructions provided by MoPub (for [banner, interstitial](https://dev.twitter.com/mopub/ui-setup/custom-network-setup) or [native](https://dev.twitter.com/mopub/ui-setup/network-setup-custom-native)) with any of the Flurry custom events class noted below:
 
-* [`FlurryBannerCustomEvent`](FlurryBannerCustomEvent.h) for Banner Ads
-* [`FlurryInterstitialCustomEvent`](FlurryInterstitialCustomEvent.h) for Interstitial Ads
-* [`FlurryNativeCustomEvent`](FlurryNativeCustomEvent.h) for Flurry Native Ads
++ [`FlurryBannerCustomEvent`](FlurryBannerCustomEvent.h) for Banner Ads
++ [`FlurryInterstitialCustomEvent`](FlurryInterstitialCustomEvent.h) for Interstitial Ads
++ [`FlurryNativeCustomEvent`](FlurryNativeCustomEvent.h) for Flurry Native Ads
 
-An important step to get this integration working is to configure a line item or segment on MoPub, setup
-Flurry API key and Flurry Ad Space (as described above) and send them as server extras
-(Custom Event class Data) for the mediation to work.
+An important step to get this integration working is to configure a line item or segment on MoPub, setup Flurry API key and Flurry Ad Space (as described above) and send them as server extras (Custom Event class Data) for the mediation to work.
 
 ![Screenshot showing ad unit/line item config on MoPub's dashboard](imgs/mopub_line_item_config.png)
 
+For full integration instructions to mediate Flurry through MoPub see [here](https://developer.yahoo.com/flurry/docs/publisher/gettingstarted/mediation/mopubmediatesflurry/ios/).
 
-
-
-For full integration instructions to mediate Flurry through MoPub see 
-[here](https://developer.yahoo.com/flurry/docs/publisher/gettingstarted/mediation/mopubmediatesflurry/ios/). 
 For more info on getting started with Flurry for iOS, see
 [here](https://developer.yahoo.com/flurry/docs/analytics/gettingstarted/ios/)
-and for more info on monetizing you app through Flurry see 
-[here](https://developer.yahoo.com/flurry/docs/publisher/code/ios/) 
+and for more info on monetizing you app through Flurry see
+[here](https://developer.yahoo.com/flurry/docs/publisher/code/ios/)
 
 Changelog
 ---------


### PR DESCRIPTION
This PR introduces the following changes to the Flurry Adapter for MoPub
- Makes it possible to install the adapter without having to modify the source code on installation. In order to make this a nicer experience, we replaced the embedded Flurry API key within the `FlurryMPConfig` singleton with `+(void)initializeWithFlurryAPIKey:(NSString *)flurryAPIKey` which developers will need to call on app load. We also updated the readme to explain the changes. Note that this is a backwards incompatible change so we should probably bump a version to the next major version after merging. (ce0e639)
- Removes some dead code from `FlurryNativeCustomEvent`. (e3760ab)
- Passes along non-standard native ad properties to MoPub so that client code can check if there are keys with `flurry_` prefix and use the additional data to render richer native ads. (5d54f6b)
- Makes sure that `FlurryInterstitialCustomEvent` calls `[self.delegate interstitialCustomEventDidAppear]` in `adInterstitialDidRender` according to [MoPub documentation](https://github.com/mopub/mopub-ios-sdk/blob/master/MoPubSDK/MPInterstitialCustomEventDelegate.h#L105). (6cf96b3)
- Tries its best to normalize the star rating to a range that MoPub expects. I had a slightly hard time finding good documentation on what you could expect to receive from `apprating` because the ads that we got returned `@"90"` but the [documentation](https://developer.yahoo.com/flurry/docs/publisher/code/ios/) hints at `@"90/100"`. Anyways, MoPub expects `@(4.5)` and we try our best to only pass along star ratings of the correct type and range. (cd8796c)
